### PR TITLE
Add getters to be able to work with the intermediate representation 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,11 @@ repository = "https://github.com/tytouf/ebustl-rs"
 readme = "README.md"
 keywords = ["stl", "subtitle", "parser"]
 categories = ["multimedia:video", "parser-implementations"]
+edition = "2018"
 
 [dependencies]
 nom = "^2.1"
 iso6937 = "^0.1"
 chrono = "^0.3"
+thiserror = "1.0"                                                               
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tytouf/ebustl-rs"
 readme = "README.md"
 keywords = ["stl", "subtitle", "parser"]
 categories = ["multimedia:video", "parser-implementations"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nom = "^2.1"

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,9 +1,9 @@
 extern crate ebustl;
 
-use std::env;
-use std::process;
-use std::error::Error;
 use ebustl::parse_stl_from_file;
+use std::env;
+use std::error::Error;
+use std::process;
 
 fn print_usage() {
     println!("dump file.stl\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ impl fmt::Display for GsiBlock {
 // TTI Block
 
 #[derive(Debug)]
-enum CumulativeStatus {
+pub enum CumulativeStatus {
     NotPartOfASet,
     FirstInSet,
     IntermediateInSet,
@@ -508,6 +508,39 @@ pub struct TtiBlock {
     cf: u8,
     #[doc="16..127 Text Field"]
     tf: Vec<u8>,
+}
+
+impl TtiBlock {
+    pub fn get_subtitle_group_number(&self) -> u8 {
+        self.sgn
+    }
+    pub fn get_subtitle_number_range(&self) -> u16 {
+        self.sn
+    }
+    pub fn extension_block_number(&self) -> u8 {
+        self.ebn
+    }
+    pub fn cumulative_status(&self) -> &CumulativeStatus {
+        &self.cs
+    }
+    pub fn time_code_in(&self) -> &Time {
+        &self.tci
+    }
+    pub fn time_code_out(&self) -> &Time {
+        &self.tco
+    }
+    pub fn vertical_position(&self) -> u8 {
+        self.vp
+    }
+    pub fn justification_code(&self) -> u8 {
+        self.jc
+    }
+    pub fn comment_flag(&self) -> u8 {
+        self.cf
+    }
+    pub fn tf(&self) -> &Vec<u8> {
+        &self.tf
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,10 +591,10 @@ impl TtiBlock {
         for i in 0..self.tf.len() {
             let c = self.tf[i];
             if match c {
-                   0x0...0x1f => true, //TODO: decode teletext control codes
-                   0x20...0x7f => false,
-                   0x7f...0x9f => true, // TODO: decode codes
-                   0xa1...0xff => false,
+                   0x0..=0x1f => true, //TODO: decode teletext control codes
+                   0x20..=0x7f => false,
+                   0x7f..=0x9f => true, // TODO: decode codes
+                   0xa1..=0xff => false,
                    _ => break,
                } {
                 if first != i {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,29 +511,26 @@ impl TtiBlock {
     pub fn get_subtitle_number_range(&self) -> u16 {
         self.sn
     }
-    pub fn extension_block_number(&self) -> u8 {
+    pub fn get_extension_block_number(&self) -> u8 {
         self.ebn
     }
-    pub fn cumulative_status(&self) -> &CumulativeStatus {
+    pub fn get_cumulative_status(&self) -> &CumulativeStatus {
         &self.cs
     }
-    pub fn time_code_in(&self) -> &Time {
+    pub fn get_time_code_in(&self) -> &Time {
         &self.tci
     }
-    pub fn time_code_out(&self) -> &Time {
+    pub fn get_time_code_out(&self) -> &Time {
         &self.tco
     }
-    pub fn vertical_position(&self) -> u8 {
+    pub fn get_vertical_position(&self) -> u8 {
         self.vp
     }
-    pub fn justification_code(&self) -> u8 {
+    pub fn get_justification_code(&self) -> u8 {
         self.jc
     }
-    pub fn comment_flag(&self) -> u8 {
+    pub fn get_comment_flag(&self) -> u8 {
         self.cf
-    }
-    pub fn tf(&self) -> &Vec<u8> {
-        &self.tf
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,10 @@ impl Stl {
     }
 
     pub fn write_to_file(&self, filename: &str) -> Result<(), io::Error> {
-        let mut f = try!(File::create(filename));
-        try!(f.write_all(&self.gsi.serialize()));
+        let mut f = File::create(filename)?;
+        f.write_all(&self.gsi.serialize())?;
         for tti in self.ttis.iter() {
-            try!(f.write_all(&tti.serialize()));
+            f.write_all(&tti.serialize())?;
         }
         Ok(())
     }
@@ -66,9 +66,9 @@ impl Stl {
 }
 
 pub fn parse_stl_from_file(filename: &str) -> Result<Stl, ParseError> {
-    let mut f = try!(File::open(filename));
+    let mut f = File::open(filename)?;
     let mut buffer = vec![];
-    try!(f.read_to_end(&mut buffer));
+    f.read_to_end(&mut buffer)?;
 
     parse_stl_from_slice(&buffer)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub fn parse_stl_from_file(filename: &str) -> Result<Stl, ParseError> {
 
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
-enum CodePageNumber {
+pub enum CodePageNumber {
     CPN_437,
     CPN_850,
     CPN_860,
@@ -116,7 +116,7 @@ impl CodePageNumber {
 }
 
 #[derive(Debug)]
-enum DisplayStandardCode {
+pub enum DisplayStandardCode {
     Blank,
     OpenSubtitling,
     Level1Teletext,
@@ -145,7 +145,7 @@ impl DisplayStandardCode {
 }
 
 #[derive(Debug)]
-enum TimeCodeStatus {
+pub enum TimeCodeStatus {
     NotIntendedForUse,
     IntendedForUse,
 }
@@ -168,7 +168,7 @@ impl TimeCodeStatus {
 }
 
 #[derive(Debug)]
-enum CharacterCodeTable {
+pub enum CharacterCodeTable {
     Latin,
     LatinCyrillic,
     LatinArabic,
@@ -219,7 +219,7 @@ impl DiskFormatCode {
         } else if data == "STL30.01" {
             Ok(DiskFormatCode::STL30_01)
         } else {
-            Err(ParseError::DiskFormatCode)
+            Err(ParseError::DiskFormatCode(data.to_string()))
         }
     }
 
@@ -302,6 +302,99 @@ pub struct GsiBlock {
     _spare: String,
     #[doc = "448..1023 User-Defined Area"]
     uda: String,
+}
+
+impl GsiBlock {
+    pub fn get_code_page_number(&self) -> &CodePageNumber {
+        &self.cpn
+    }
+    pub fn get_disk_format_code(&self) -> &DiskFormatCode {
+        &self.dfc
+    }
+    pub fn get_display_standard_code(&self) -> &DisplayStandardCode {
+        &self.dsc
+    }
+    pub fn get_character_code_table(&self) -> &CharacterCodeTable {
+        &self.cct
+    }
+    pub fn get_language_code(&self) -> &str {
+        &self.lc
+    }
+    pub fn get_original_program_title(&self) -> &str {
+        &self.opt
+    }
+    pub fn get_original_episode_title(&self) -> &str {
+        &self.oet
+    }
+    pub fn get_translated_program_title(&self) -> &str {
+        &self.tpt
+    }
+    pub fn get_translated_episode_title(&self) -> &str {
+        &self.tet
+    }
+    pub fn get_translators_name(&self) -> &str {
+        &self.tn
+    }
+    pub fn get_translators_contact_details(&self) -> &str {
+        &self.tcd
+    }
+    pub fn get_subtitle_list_reference_code(&self) -> &str {
+        &self.slr
+    }
+    pub fn get_creation_date(&self) -> &str {
+        &self.cd
+    }
+    pub fn get_revision_date(&self) -> &str {
+        &self.rd
+    }
+    pub fn get_revision_number(&self) -> &str {
+        &self.rn
+    }
+    pub fn get_total_number_of_text_and_timing_blocks(&self) -> u16 {
+        self.tnb
+    }
+    pub fn get_total_number_of_subtitles(&self) -> u16 {
+        self.tns
+    }
+    pub fn get_total_number_of_chars_in_row(&self) -> u16 {
+        self.tng
+    }
+    pub fn get_max_number_of_chars_in_row(&self) -> u16 {
+        self.mnc
+    }
+    pub fn get_max_number_of_rows(&self) -> u16 {
+        self.mnr
+    }
+    pub fn get_timecode_status(&self) -> &TimeCodeStatus {
+        &self.tcs
+    }
+    pub fn get_timecode_start_of_program(&self) -> &str {
+        &self.tcp
+    }
+    pub fn get_timecode_first_in_cue(&self) -> &str {
+        &self.tcf
+    }
+    pub fn get_total_number_of_disks(&self) -> u8 {
+        self.tnd
+    }
+    pub fn get_disk_sequence_number(&self) -> u8 {
+        self.dsn
+    }
+    pub fn get_country_of_origin(&self) -> &str {
+        &self.co
+    }
+    pub fn get_publisher(&self) -> &str {
+        &self.pub_
+    }
+    pub fn get_editors_name(&self) -> &str {
+        &self.en
+    }
+    pub fn get_editors_contact_details(&self) -> &str {
+        &self.ecd
+    }
+    pub fn get_user_defined_area(&self) -> &str {
+        &self.uda
+    }
 }
 
 fn push_string(v: &mut Vec<u8>, s: &String, len: usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 #[macro_use]
 extern crate nom;
-extern crate iso6937;
 extern crate chrono;
+extern crate iso6937;
 
 use std::fmt;
-use std::str;
+use std::fs::File;
 use std::io;
 use std::io::prelude::*;
-use std::fs::File;
+use std::str;
 
 pub mod parser;
-pub use parser::ParseError;
-use parser::parse_stl_from_slice;
+use crate::parser::parse_stl_from_slice;
+pub use crate::parser::ParseError;
 
 // STL File
 
@@ -28,11 +28,11 @@ impl fmt::Display for Stl {
 }
 
 pub struct TtiFormat {
-    #[doc="Justification Code"]
+    #[doc = "Justification Code"]
     pub jc: u8,
-    #[doc="Vertical Position"]
+    #[doc = "Vertical Position"]
     pub vp: u8,
-    #[doc="Double Height"]
+    #[doc = "Double Height"]
     pub dh: bool,
 }
 
@@ -73,7 +73,6 @@ pub fn parse_stl_from_file(filename: &str) -> Result<Stl, ParseError> {
     parse_stl_from_slice(&buffer)
 }
 
-
 // GSI Block
 
 #[derive(Debug)]
@@ -107,15 +106,14 @@ impl CodePageNumber {
 
     fn serialize(&self) -> Vec<u8> {
         return match *self {
-                   CodePageNumber::CPN_437 => vec![0x34, 0x33, 0x37],
-                   CodePageNumber::CPN_850 => vec![0x38, 0x35, 0x30],
-                   CodePageNumber::CPN_860 => vec![0x38, 0x36, 0x30],
-                   CodePageNumber::CPN_863 => vec![0x38, 0x36, 0x33],
-                   CodePageNumber::CPN_865 => vec![0x38, 0x36, 0x35],
-               };
+            CodePageNumber::CPN_437 => vec![0x34, 0x33, 0x37],
+            CodePageNumber::CPN_850 => vec![0x38, 0x35, 0x30],
+            CodePageNumber::CPN_860 => vec![0x38, 0x36, 0x30],
+            CodePageNumber::CPN_863 => vec![0x38, 0x36, 0x33],
+            CodePageNumber::CPN_865 => vec![0x38, 0x36, 0x35],
+        };
     }
 }
-
 
 #[derive(Debug)]
 enum DisplayStandardCode {
@@ -128,21 +126,21 @@ enum DisplayStandardCode {
 impl DisplayStandardCode {
     fn parse(data: u8) -> Result<DisplayStandardCode, ParseError> {
         return match data {
-                   0x20 => Ok(DisplayStandardCode::Blank),
-                   0x30 => Ok(DisplayStandardCode::OpenSubtitling),
-                   0x31 => Ok(DisplayStandardCode::Level1Teletext),
-                   0x32 => Ok(DisplayStandardCode::Level2Teletext),
-                   _ => Err(ParseError::DisplayStandardCode),
-               };
+            0x20 => Ok(DisplayStandardCode::Blank),
+            0x30 => Ok(DisplayStandardCode::OpenSubtitling),
+            0x31 => Ok(DisplayStandardCode::Level1Teletext),
+            0x32 => Ok(DisplayStandardCode::Level2Teletext),
+            _ => Err(ParseError::DisplayStandardCode),
+        };
     }
 
     fn serialize(&self) -> u8 {
         return match *self {
-                   DisplayStandardCode::Blank => 0x20,
-                   DisplayStandardCode::OpenSubtitling => 0x30,
-                   DisplayStandardCode::Level1Teletext => 0x31,
-                   DisplayStandardCode::Level2Teletext => 0x32,
-               };
+            DisplayStandardCode::Blank => 0x20,
+            DisplayStandardCode::OpenSubtitling => 0x30,
+            DisplayStandardCode::Level1Teletext => 0x31,
+            DisplayStandardCode::Level2Teletext => 0x32,
+        };
     }
 }
 
@@ -155,20 +153,19 @@ enum TimeCodeStatus {
 impl TimeCodeStatus {
     fn parse(data: u8) -> Result<TimeCodeStatus, ParseError> {
         return match data {
-                   0x30 => Ok(TimeCodeStatus::NotIntendedForUse),
-                   0x31 => Ok(TimeCodeStatus::IntendedForUse),
-                   _ => Err(ParseError::TimeCodeStatus),
-               };
+            0x30 => Ok(TimeCodeStatus::NotIntendedForUse),
+            0x31 => Ok(TimeCodeStatus::IntendedForUse),
+            _ => Err(ParseError::TimeCodeStatus),
+        };
     }
 
     fn serialize(&self) -> u8 {
         return match *self {
-                   TimeCodeStatus::NotIntendedForUse => 0x30,
-                   TimeCodeStatus::IntendedForUse => 0x31,
-               };
+            TimeCodeStatus::NotIntendedForUse => 0x30,
+            TimeCodeStatus::IntendedForUse => 0x31,
+        };
     }
 }
-
 
 #[derive(Debug)]
 enum CharacterCodeTable {
@@ -199,12 +196,12 @@ impl CharacterCodeTable {
 
     fn serialize(&self) -> Vec<u8> {
         return match *self {
-                   CharacterCodeTable::Latin => vec![0x30, 0x30],
-                   CharacterCodeTable::LatinCyrillic => vec![0x30, 0x31],
-                   CharacterCodeTable::LatinArabic => vec![0x30, 0x32],
-                   CharacterCodeTable::LatinGreek => vec![0x30, 0x33],
-                   CharacterCodeTable::LatinHebrew => vec![0x30, 0x34],
-               };
+            CharacterCodeTable::Latin => vec![0x30, 0x30],
+            CharacterCodeTable::LatinCyrillic => vec![0x30, 0x31],
+            CharacterCodeTable::LatinArabic => vec![0x30, 0x32],
+            CharacterCodeTable::LatinGreek => vec![0x30, 0x33],
+            CharacterCodeTable::LatinHebrew => vec![0x30, 0x34],
+        };
     }
 }
 
@@ -228,82 +225,82 @@ impl DiskFormatCode {
 
     fn serialize(&self) -> Vec<u8> {
         return match *self {
-                   DiskFormatCode::STL25_01 => String::from("STL25.01").into_bytes(),
-                   DiskFormatCode::STL30_01 => String::from("STL30.01").into_bytes(),
-               };
+            DiskFormatCode::STL25_01 => String::from("STL25.01").into_bytes(),
+            DiskFormatCode::STL30_01 => String::from("STL30.01").into_bytes(),
+        };
     }
 
-    pub fn get_fps(self) -> usize {
+    pub fn get_fps(&self) -> usize {
         return match self {
-                   DiskFormatCode::STL25_01 => 25,
-                   DiskFormatCode::STL30_01 => 30,
-               };
+            DiskFormatCode::STL25_01 => 25,
+            DiskFormatCode::STL30_01 => 30,
+        };
     }
 }
 
 #[derive(Debug)]
 pub struct GsiBlock {
-    #[doc="0..2 Code Page Number"]
+    #[doc = "0..2 Code Page Number"]
     cpn: CodePageNumber,
-    #[doc="3..10 Disk Format Code"]
+    #[doc = "3..10 Disk Format Code"]
     dfc: DiskFormatCode,
-    #[doc="11 Display Standard Code"]
+    #[doc = "11 Display Standard Code"]
     dsc: DisplayStandardCode,
-    #[doc="12..13 Character Code Table Number"]
+    #[doc = "12..13 Character Code Table Number"]
     cct: CharacterCodeTable,
-    #[doc="14..15 Language Code"]
+    #[doc = "14..15 Language Code"]
     lc: String,
-    #[doc="16..47 Original Program Title"]
+    #[doc = "16..47 Original Program Title"]
     opt: String,
-    #[doc="48..79 Original Episode Title"]
+    #[doc = "48..79 Original Episode Title"]
     oet: String,
-    #[doc="80..111 Translated Program Title"]
+    #[doc = "80..111 Translated Program Title"]
     tpt: String,
-    #[doc="112..143 Translated Episode Title"]
+    #[doc = "112..143 Translated Episode Title"]
     tet: String,
-    #[doc="144..175 Translator's Name"]
+    #[doc = "144..175 Translator's Name"]
     tn: String,
-    #[doc="176..207 Translator's Contact Details"]
+    #[doc = "176..207 Translator's Contact Details"]
     tcd: String,
-    #[doc="208..223 Subtitle List Reference Code"]
+    #[doc = "208..223 Subtitle List Reference Code"]
     slr: String,
-    #[doc="224..229 Creation Date"]
+    #[doc = "224..229 Creation Date"]
     cd: String,
-    #[doc="230..235 Revision Date"]
+    #[doc = "230..235 Revision Date"]
     rd: String,
-    #[doc="236..237 Revision Number"]
+    #[doc = "236..237 Revision Number"]
     rn: String,
-    #[doc="238..242 Total Number of Text and Timing Blocks"]
+    #[doc = "238..242 Total Number of Text and Timing Blocks"]
     tnb: u16,
-    #[doc="243..247 Total Number of Subtitles"]
+    #[doc = "243..247 Total Number of Subtitles"]
     tns: u16,
-    #[doc="248..250 Total Number of Subtitle Groups"]
+    #[doc = "248..250 Total Number of Subtitle Groups"]
     tng: u16,
-    #[doc="251..252 Maximum Number of Displayable Characters in a Text Row"]
+    #[doc = "251..252 Maximum Number of Displayable Characters in a Text Row"]
     mnc: u16,
-    #[doc="253..254 Maximum Number of Displayable Rows"]
+    #[doc = "253..254 Maximum Number of Displayable Rows"]
     mnr: u16,
-    #[doc="255 Time Code Status"]
+    #[doc = "255 Time Code Status"]
     tcs: TimeCodeStatus,
-    #[doc="256..263 Time Code: Start of Programme (format: HHMMSSFF)"]
+    #[doc = "256..263 Time Code: Start of Programme (format: HHMMSSFF)"]
     tcp: String,
-    #[doc="264..271 Time Code: First-in-Cue (format: HHMMSSFF)"]
+    #[doc = "264..271 Time Code: First-in-Cue (format: HHMMSSFF)"]
     tcf: String,
-    #[doc="272 Total Number of Disks"]
+    #[doc = "272 Total Number of Disks"]
     tnd: u8,
-    #[doc="273 Disk Sequence Number"]
+    #[doc = "273 Disk Sequence Number"]
     dsn: u8,
-    #[doc="274..276 Country of Origin"]
+    #[doc = "274..276 Country of Origin"]
     co: String, // TODO Type with country definitions
-    #[doc="277..308 Publisher"]
+    #[doc = "277..308 Publisher"]
     pub_: String,
-    #[doc="309..340 Editor's Name"]
+    #[doc = "309..340 Editor's Name"]
     en: String,
-    #[doc="341..372 Editor's Contact Details"]
+    #[doc = "341..372 Editor's Contact Details"]
     ecd: String,
-    #[doc="373..447 Spare Bytes"]
+    #[doc = "373..447 Spare Bytes"]
     _spare: String,
-    #[doc="448..1023 User-Defined Area"]
+    #[doc = "448..1023 User-Defined Area"]
     uda: String,
 }
 
@@ -336,7 +333,7 @@ impl GsiBlock {
             rn: "00".to_string(),
             tnb: 0,
             tns: 0,
-            tng: 1, // At least one group?
+            tng: 1,  // At least one group?
             mnc: 40, // FIXME: ok for default?
             mnr: 23, // FIXME: ok for default?
             tcs: TimeCodeStatus::IntendedForUse,
@@ -356,10 +353,7 @@ impl GsiBlock {
     fn serialize(&self) -> Vec<u8> {
         let mut res = Vec::with_capacity(1024);
         res.extend(self.cpn.serialize());
-        res.extend(self.dfc
-                       .serialize()
-                       .iter()
-                       .cloned());
+        res.extend(self.dfc.serialize().iter().cloned());
         res.push(self.dsc.serialize());
         res.extend(self.cct.serialize());
         // be careful for the length of following: must force padding
@@ -399,12 +393,11 @@ impl GsiBlock {
 
 impl fmt::Display for GsiBlock {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "Program Title: {}\nEpisode Title: {}\ncct:{:?} lc:{}\n",
-               self.opt,
-               self.oet,
-               self.cct,
-               self.lc)
+        write!(
+            f,
+            "Program Title: {}\nEpisode Title: {}\ncct:{:?} lc:{}\n",
+            self.opt, self.oet, self.cct, self.lc
+        )
     }
 }
 
@@ -421,21 +414,21 @@ pub enum CumulativeStatus {
 impl CumulativeStatus {
     fn parse(d: u8) -> Result<CumulativeStatus, ParseError> {
         return match d {
-                   0 => Ok(CumulativeStatus::NotPartOfASet),
-                   1 => Ok(CumulativeStatus::FirstInSet),
-                   2 => Ok(CumulativeStatus::IntermediateInSet),
-                   3 => Ok(CumulativeStatus::LastInSet),
-                   _ => Err(ParseError::CumulativeStatus),
-               };
+            0 => Ok(CumulativeStatus::NotPartOfASet),
+            1 => Ok(CumulativeStatus::FirstInSet),
+            2 => Ok(CumulativeStatus::IntermediateInSet),
+            3 => Ok(CumulativeStatus::LastInSet),
+            _ => Err(ParseError::CumulativeStatus),
+        };
     }
 
     fn serialize(&self) -> u8 {
         return match *self {
-                   CumulativeStatus::NotPartOfASet => 0,
-                   CumulativeStatus::FirstInSet => 1,
-                   CumulativeStatus::IntermediateInSet => 2,
-                   CumulativeStatus::LastInSet => 3,
-               };
+            CumulativeStatus::NotPartOfASet => 0,
+            CumulativeStatus::FirstInSet => 1,
+            CumulativeStatus::IntermediateInSet => 2,
+            CumulativeStatus::LastInSet => 3,
+        };
     }
 }
 
@@ -465,11 +458,13 @@ impl Time {
     }
 
     pub fn format_fps(&self, fps: usize) -> String {
-        format!("{}:{}:{},{}",
-                self.hours,
-                self.minutes,
-                self.seconds,
-                self.frames as usize * 1000 / fps)
+        format!(
+            "{}:{}:{},{}",
+            self.hours,
+            self.minutes,
+            self.seconds,
+            self.frames as usize * 1000 / fps
+        )
     }
     fn serialize(&self) -> Vec<u8> {
         vec![self.hours, self.minutes, self.seconds, self.frames]
@@ -478,35 +473,34 @@ impl Time {
 
 impl fmt::Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "{}:{}:{}/{})",
-               self.hours,
-               self.minutes,
-               self.seconds,
-               self.frames)
+        write!(
+            f,
+            "{}:{}:{}/{})",
+            self.hours, self.minutes, self.seconds, self.frames
+        )
     }
 }
 
 pub struct TtiBlock {
-    #[doc="0 Subtitle Group Number. 00h-FFh"]
+    #[doc = "0 Subtitle Group Number. 00h-FFh"]
     sgn: u8,
-    #[doc="1..2 Subtitle Number range. 0000h-FFFFh"]
+    #[doc = "1..2 Subtitle Number range. 0000h-FFFFh"]
     sn: u16,
-    #[doc="3 Extension Block Number. 00h-FFh"]
+    #[doc = "3 Extension Block Number. 00h-FFh"]
     ebn: u8,
-    #[doc="4 Cumulative Status. 00-03h"]
+    #[doc = "4 Cumulative Status. 00-03h"]
     cs: CumulativeStatus,
-    #[doc="5..8 Time Code In"]
+    #[doc = "5..8 Time Code In"]
     tci: Time,
-    #[doc="9..12 Time Code Out"]
+    #[doc = "9..12 Time Code Out"]
     tco: Time,
-    #[doc="13 Vertical Position"]
+    #[doc = "13 Vertical Position"]
     vp: u8,
-    #[doc="14 Justification Code"]
+    #[doc = "14 Justification Code"]
     jc: u8,
-    #[doc="15 Comment Flag"]
+    #[doc = "15 Comment Flag"]
     cf: u8,
-    #[doc="16..127 Text Field"]
+    #[doc = "16..127 Text Field"]
     tf: Vec<u8>,
 }
 
@@ -543,7 +537,6 @@ impl TtiBlock {
     }
 }
 
-
 impl TtiBlock {
     pub fn new(idx: u16, tci: Time, tco: Time, txt: &str, opt: TtiFormat) -> TtiBlock {
         TtiBlock {
@@ -551,8 +544,8 @@ impl TtiBlock {
             sn: idx,
             ebn: 0xff,
             cs: CumulativeStatus::NotPartOfASet,
-            tci: tci,
-            tco: tco,
+            tci,
+            tco,
             vp: opt.vp,
             jc: opt.jc,
             cf: 0,
@@ -591,12 +584,11 @@ impl TtiBlock {
         for i in 0..self.tf.len() {
             let c = self.tf[i];
             if match c {
-                   0x0..=0x1f => true, //TODO: decode teletext control codes
-                   0x20..=0x7f => false,
-                   0x7f..=0x9f => true, // TODO: decode codes
-                   0xa1..=0xff => false,
-                   _ => break,
-               } {
+                0x0..=0x1f => true, //TODO: decode teletext control codes
+                0x20..=0x7f => false,
+                0x80..=0x9f => true, // TODO: decode codes
+                0xa0..=0xff => false,
+            } {
                 if first != i {
                     result.push_str(&iso6937::decode(&self.tf[first..i]));
                 }
@@ -618,14 +610,8 @@ impl TtiBlock {
         res.push((self.sn >> 8) as u8);
         res.push(self.ebn);
         res.push(self.cs.serialize());
-        res.extend(self.tci
-                       .serialize()
-                       .iter()
-                       .cloned());
-        res.extend(self.tco
-                       .serialize()
-                       .iter()
-                       .cloned());
+        res.extend(self.tci.serialize().iter().cloned());
+        res.extend(self.tco.serialize().iter().cloned());
         res.push(self.vp);
         res.push(self.jc);
         res.push(self.cf);
@@ -636,30 +622,34 @@ impl TtiBlock {
 
 impl fmt::Debug for TtiBlock {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "\n{}-->{} sgn:{} sn:{} ebn:{} cs:{:?} vp:{} jc:{} cf:{} [{}]",
-               self.tci,
-               self.tco,
-               self.sgn,
-               self.sn,
-               self.ebn,
-               self.cs,
-               self.vp,
-               self.jc,
-               self.cf,
-               self.get_text())
+        write!(
+            f,
+            "\n{}-->{} sgn:{} sn:{} ebn:{} cs:{:?} vp:{} jc:{} cf:{} [{}]",
+            self.tci,
+            self.tco,
+            self.sgn,
+            self.sn,
+            self.ebn,
+            self.cs,
+            self.vp,
+            self.jc,
+            self.cf,
+            self.get_text()
+        )
     }
 }
 
 impl fmt::Display for TtiBlock {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "\n{} {} {} {} {:?} [{}]",
-               self.tci,
-               self.sgn,
-               self.sn,
-               self.ebn,
-               self.cs,
-               self.get_text())
+        write!(
+            f,
+            "\n{} {} {} {} {:?} [{}]",
+            self.tci,
+            self.sgn,
+            self.sn,
+            self.ebn,
+            self.cs,
+            self.get_text()
+        )
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,7 @@ impl error::Error for ParseError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,64 +1,42 @@
-use nom::{IResult, be_u8, le_u16};
-use std::error;
-use std::error::Error;
-use std::io;
-use std::str;
 use std::str::FromStr;
+
+use nom::{be_u8, le_u16, IResult};
+use thiserror::Error;
 
 use super::*;
 
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParseError {
-    Io(io::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("Error parsing, file may be incomplete or corrupted")]
     Incomplete,
+    #[error("Error parsing Code Page Number")]
     CodePageNumber,
+    #[error("Error parsing Display Standard Code")]
     DisplayStandardCode,
+    #[error("Error parsing Time Code Status")]
     TimeCodeStatus,
+    #[error("Error parsing Disk Format Code")]
     DiskFormatCode,
+    #[error("Error parsing Character Code Table")]
     CharacterCodeTable,
+    #[error("Error parsing Cumulative Status")]
     CumulativeStatus,
+    #[error("Unknown error")]
     Unknown,
 }
 
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ParseError: {}", self.description())
-    }
-}
-
-impl error::Error for ParseError {
-    fn description(&self) -> &str {
-        match *self {
-            ParseError::Io(ref err) => err.description(),
-            ParseError::Incomplete => "Error parsing, file may be incomplete or corrupted",
-            ParseError::CodePageNumber => "Error parsing Code Page Number",
-            ParseError::DisplayStandardCode => "Error parsing Display Standard Code",
-            ParseError::TimeCodeStatus => "Error parsing Time Code Status",
-            ParseError::DiskFormatCode => "Error parsing Disk Format Code",
-            ParseError::CharacterCodeTable => "Error parsing Character Code Table",
-            ParseError::CumulativeStatus => "Error parsing Cumulative Status",
-            ParseError::Unknown => "Unknown error",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
-
-impl From<io::Error> for ParseError {
-    fn from(err: io::Error) -> ParseError {
-        ParseError::Io(err)
-    }
-}
-
-named!(parse_stl<Stl>,
-  do_parse!(
-    gsi: parse_gsi_block >>
-    ttis: many1!(parse_tti_block) >>
-    (Stl{gsi: gsi, ttis: ttis})
-  )
+named!(
+    parse_stl<Stl>,
+    do_parse!(
+        gsi: parse_gsi_block
+            >> ttis: many1!(parse_tti_block)
+            >> (Stl {
+                gsi: gsi,
+                ttis: ttis
+            })
+    )
 );
 
 pub fn parse_stl_from_slice(input: &[u8]) -> Result<Stl, ParseError> {
@@ -69,81 +47,115 @@ pub fn parse_stl_from_slice(input: &[u8]) -> Result<Stl, ParseError> {
     }
 }
 
-named!(parse_gsi_block<GsiBlock>,
-  do_parse!(
-    cpn: map_res!(take!(3), CodePageNumber::parse)       >>
-    dfc: map_res!(take_str!(10-3+1), DiskFormatCode::parse)    >>
-    dsc: map_res!(be_u8, DisplayStandardCode::parse)       >>
-    cct: map_res!(take!(13-12+1), CharacterCodeTable::parse)   >>
-    lc: map_res!(take_str!(15-14+1), String::from_str)   >>
-    opt: map_res!(take_str!(47-16+1), String::from_str)  >>
-    oet: map_res!(take_str!(79-48+1), String::from_str)  >>
-    tpt: map_res!(take_str!(111-80+1), String::from_str)  >>
-    tet: map_res!(take_str!(143-112+1), String::from_str)  >>
-    tn: map_res!(take_str!(175-144+1), String::from_str)  >>
-    tcd: map_res!(take_str!(207-176+1), String::from_str)  >>
-    slr: map_res!(take_str!(223-208+1), String::from_str)  >>
-    cd: map_res!(take_str!(229-224+1), String::from_str)  >>
-    rd: map_res!(take_str!(235-230+1), String::from_str)  >>
-    rn: map_res!(take_str!(237-236+1), String::from_str)  >>
-    tnb: map_res!(take_str!(242-238+1), u16::from_str)   >>
-    tns: map_res!(take_str!(247-243+1), u16::from_str)   >>
-    tng: map_res!(take_str!(250-248+1), u16::from_str)   >>
-    mnc: map_res!(take_str!(252-251+1), u16::from_str)   >>
-    mnr: map_res!(take_str!(254-253+1), u16::from_str)   >>
-    tcs: map_res!(be_u8, TimeCodeStatus::parse)   >>
-    tcp: map_res!(take_str!(263-256+1), String::from_str)  >>
-    tcf: map_res!(take_str!(271-264+1), String::from_str)  >>
-    tnd: map_res!(take_str!(1), u8::from_str)   >>
-    dsn: map_res!(take_str!(1), u8::from_str)   >>
-    co: map_res!(take_str!(276-274+1), String::from_str)  >>
-    pub_: map_res!(take_str!(308-277+1), String::from_str)  >>
-    en: map_res!(take_str!(340-309+1), String::from_str)  >>
-    ecd: map_res!(take_str!(372-341+1), String::from_str)  >>
-    _spare: map_res!(take_str!(447-373+1), String::from_str)  >>
-    uda: map_res!(take_str!(1023-448+1), String::from_str)  >>
-    (GsiBlock{
-        cpn: cpn, dfc: dfc, dsc: dsc, cct: cct, lc: lc,
-        opt: opt, oet: oet, tpt: tpt, tet: tet, tn: tn, tcd: tcd, slr: slr,
-        cd: cd, rd: rd, rn: rn, tnb: tnb, tns: tns, tng: tng,
-        mnc: mnc, mnr: mnr, tcs: tcs, tcp: tcp, tcf: tcf, tnd: tnd, dsn: dsn,
-        co: co, pub_: pub_, en: en, ecd: ecd, _spare: _spare, uda: uda,
-        })
-  )
+named!(
+    parse_gsi_block<GsiBlock>,
+    do_parse!(
+        cpn: map_res!(take!(3), CodePageNumber::parse)
+            >> dfc: map_res!(take_str!(10 - 3 + 1), DiskFormatCode::parse)
+            >> dsc: map_res!(be_u8, DisplayStandardCode::parse)
+            >> cct: map_res!(take!(13 - 12 + 1), CharacterCodeTable::parse)
+            >> lc: map_res!(take_str!(15 - 14 + 1), String::from_str)
+            >> opt: map_res!(take_str!(47 - 16 + 1), String::from_str)
+            >> oet: map_res!(take_str!(79 - 48 + 1), String::from_str)
+            >> tpt: map_res!(take_str!(111 - 80 + 1), String::from_str)
+            >> tet: map_res!(take_str!(143 - 112 + 1), String::from_str)
+            >> tn: map_res!(take_str!(175 - 144 + 1), String::from_str)
+            >> tcd: map_res!(take_str!(207 - 176 + 1), String::from_str)
+            >> slr: map_res!(take_str!(223 - 208 + 1), String::from_str)
+            >> cd: map_res!(take_str!(229 - 224 + 1), String::from_str)
+            >> rd: map_res!(take_str!(235 - 230 + 1), String::from_str)
+            >> rn: map_res!(take_str!(237 - 236 + 1), String::from_str)
+            >> tnb: map_res!(take_str!(242 - 238 + 1), u16::from_str)
+            >> tns: map_res!(take_str!(247 - 243 + 1), u16::from_str)
+            >> tng: map_res!(take_str!(250 - 248 + 1), u16::from_str)
+            >> mnc: map_res!(take_str!(252 - 251 + 1), u16::from_str)
+            >> mnr: map_res!(take_str!(254 - 253 + 1), u16::from_str)
+            >> tcs: map_res!(be_u8, TimeCodeStatus::parse)
+            >> tcp: map_res!(take_str!(263 - 256 + 1), String::from_str)
+            >> tcf: map_res!(take_str!(271 - 264 + 1), String::from_str)
+            >> tnd: map_res!(take_str!(1), u8::from_str)
+            >> dsn: map_res!(take_str!(1), u8::from_str)
+            >> co: map_res!(take_str!(276 - 274 + 1), String::from_str)
+            >> pub_: map_res!(take_str!(308 - 277 + 1), String::from_str)
+            >> en: map_res!(take_str!(340 - 309 + 1), String::from_str)
+            >> ecd: map_res!(take_str!(372 - 341 + 1), String::from_str)
+            >> _spare: map_res!(take_str!(447 - 373 + 1), String::from_str)
+            >> uda: map_res!(take_str!(1023 - 448 + 1), String::from_str)
+            >> (GsiBlock {
+                cpn: cpn,
+                dfc: dfc,
+                dsc: dsc,
+                cct: cct,
+                lc: lc,
+                opt: opt,
+                oet: oet,
+                tpt: tpt,
+                tet: tet,
+                tn: tn,
+                tcd: tcd,
+                slr: slr,
+                cd: cd,
+                rd: rd,
+                rn: rn,
+                tnb: tnb,
+                tns: tns,
+                tng: tng,
+                mnc: mnc,
+                mnr: mnr,
+                tcs: tcs,
+                tcp: tcp,
+                tcf: tcf,
+                tnd: tnd,
+                dsn: dsn,
+                co: co,
+                pub_: pub_,
+                en: en,
+                ecd: ecd,
+                _spare: _spare,
+                uda: uda,
+            })
+    )
 );
 
-named!(parse_time<Time>,
-  do_parse!(
-    h: be_u8 >>
-    m: be_u8 >>
-    s: be_u8 >>
-    f: be_u8 >>
-    (Time::new(h, m, s, f))
-  )
+named!(
+    parse_time<Time>,
+    do_parse!(h: be_u8 >> m: be_u8 >> s: be_u8 >> f: be_u8 >> (Time::new(h, m, s, f)))
 );
 
-named!(parse_tti_block<TtiBlock>,
-  do_parse!(
-	sgn: be_u8 >>
-    sn: le_u16 >>
-    ebn: be_u8 >>
-    cs: map_res!(be_u8, CumulativeStatus::parse) >>
-    tci: parse_time >>
-    tco: parse_time >>
-    vp: be_u8 >>
-    jc: be_u8 >>
-    cf: be_u8 >>
-    tf: take!(112) >>
-    (TtiBlock{sgn: sgn, sn: sn, ebn: ebn, cs: cs, tci: tci, tco: tco, vp: vp,
-        jc: jc, cf: cf, tf: tf.to_vec()})
-  )
+named!(
+    parse_tti_block<TtiBlock>,
+    do_parse!(
+        sgn: be_u8
+            >> sn: le_u16
+            >> ebn: be_u8
+            >> cs: map_res!(be_u8, CumulativeStatus::parse)
+            >> tci: parse_time
+            >> tco: parse_time
+            >> vp: be_u8
+            >> jc: be_u8
+            >> cf: be_u8
+            >> tf: take!(112)
+            >> (TtiBlock {
+                sgn: sgn,
+                sn: sn,
+                ebn: ebn,
+                cs: cs,
+                tci: tci,
+                tco: tco,
+                vp: vp,
+                jc: jc,
+                cf: cf,
+                tf: tf.to_vec()
+            })
+    )
 );
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nom::IResult::*;
     use nom::Needed;
+
+    use super::*;
 
     #[test]
     fn test_parse_time() {
@@ -151,13 +163,22 @@ mod tests {
         let ok = &vec![0x1, 0x2, 0x3, 0x4];
         let incomplete = &vec![0x1];
 
-        assert_eq!(parse_time(ok), Done(empty, Time{
-            hours: 1,
-            minutes: 2,
-            seconds: 3,
-            frames: 4,
-            }));
-        assert_eq!(parse_time(incomplete), Incomplete(Needed::Size(incomplete.len()+1)));
+        assert_eq!(
+            parse_time(ok),
+            Done(
+                empty,
+                Time {
+                    hours: 1,
+                    minutes: 2,
+                    seconds: 3,
+                    frames: 4,
+                }
+            )
+        );
+        assert_eq!(
+            parse_time(incomplete),
+            Incomplete(Needed::Size(incomplete.len() + 1))
+        );
     }
 
     /* TODO

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,8 +17,8 @@ pub enum ParseError {
     DisplayStandardCode,
     #[error("Error parsing Time Code Status")]
     TimeCodeStatus,
-    #[error("Error parsing Disk Format Code")]
-    DiskFormatCode,
+    #[error("Error parsing Disk Format Code: {0}")]
+    DiskFormatCode(String),
     #[error("Error parsing Character Code Table")]
     CharacterCodeTable,
     #[error("Error parsing Cumulative Status")]


### PR DESCRIPTION
I needed to access the timing information and texts and so on, so I have added a bunch of getters. I also have bumped the Rust Edition, fixes some lint warnings and so on. 